### PR TITLE
fix(settings): Fix update settings bug

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -42,8 +42,8 @@ logseq.useSettingsSchema(settingsSchema);
 async function runOpenAI(b: IHookEvent) {
   const apiKey = logseq.settings!["openAIKey"];
   const completionEngine = logseq.settings!["openAICompletionEngine"];
-  const temperature = logseq.settings!["openAITemperature"];
-  const maxTokens = logseq.settings!["openAIMaxTokens"];
+  const temperature = Number.parseFloat(logseq.settings!["openAITemperature"]);
+  const maxTokens = Number.parseInt(logseq.settings!["openAIMaxTokens"]);
 
   if (!apiKey) {
     console.error("Need API key set in settings.");


### PR DESCRIPTION
Even though logseq specifies this as a number, and enforces the input is
a number, it gets saved as a string. This parses it if neccesary.

closes #6 