### PR TITLE
feat(error-handling): Improve error handling and messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,6 @@ Write a GPT-3 command in a block, then run the open `gpt3` command via the slash
 See [this article for a good overview.](https://www.vox.com/future-perfect/21355768/gpt-3-ai-openai-turing-test-language)
 
 ###  Errors
-I see an "OpenAI Plugin Error"
-
-![openai](docs/openai-error.png)]
-
-- Open the developer tools (Menu -> View -> Toggle Developer tools)
-
-![](docs/debug.png)
-
-![](docs/response.png)
-
-- See if you can figure out the error on your own. Maybe you had a network issue if it says something like "timed out." Sometimes the OpenAI API has issues. You also have a limited number of tokens, so you may run out and need to refill. 
 #### OpenAI Quota Reached
 
 Your free trial is over, or you've run out of tokens. You can refill your tokens [here](https://beta.openai.com/account/billing/overview).
@@ -119,6 +108,19 @@ Your free trial is over, or you've run out of tokens. You can refill your tokens
 OpenAI has limits on how often you can call them. If you get this error, you'll need to wait a bit before trying again. See this [article](https://help.openai.com/en/articles/5955598-is-api-usage-subject-to-any-rate-limits) for more info on the rate limits. You can call it faster if you have a paid account.
 #### `Refused to set unsafe header "User Agent"`
 This error doesn't cause any issues besides the error message in the console. It's a known issue with the OpenAI API. See [this issue](https://github.com/openai/openai-node/issues/6) for more details. I'm working on a PR to their library to support browser usage. Ignore this error for now.
+
+### Debugging
+![openai](docs/openai-error.png)]
+
+- Open the developer tools (Menu -> View -> Toggle Developer tools)
+
+- Check the console logs for error messages.
+
+![](docs/debug.png)
+
+![](docs/response.png)
+
+- See if you can figure out the error on your own. Maybe you had a network issue if it says something like "timed out." Sometimes the OpenAI API has issues. You also have a limited number of tokens, so you may run out and need to refill. 
 
 - If you can't figure it out based on the error message and it doesn't go away. Make an issue on GitHub.
 ### Prerequisites


### PR DESCRIPTION
OpenAI will return a 429 error when your free trial is over or you run out of credits. It will also return a 429 error if you call the API too fast. This PR will show a better error message when you run out of credits, and retry behind the scenes for normal rate limiting errors.