### PR TITLE
feat(templates): Allow user to set the temperature for each prompt

### DIFF
--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -52,6 +52,7 @@ export async function loadUserCommands() {
       customCommands.push({
         type: type,
         name: type,
+        temperature: Number(result[0].properties["prompt-temperature"]),
         prompt: prompt,
       });
     }
@@ -62,6 +63,7 @@ export async function loadUserCommands() {
 
 interface Prompt {
   name: string;
+  temperature: number;
   description: string;
   prompt: string;
 }
@@ -74,6 +76,7 @@ function promptsToCommands(prompts: Prompts): Command[] {
       name: prompt.name,
       description: prompt.description,
       prompt: prompt.prompt,
+      temperature: prompt.temperature,
     };
   });
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -34,7 +34,8 @@ export const settingsSchema: SettingSchemaDesc[] = [
     default: 1.0,
     title: "OpenAI Temperature",
     description:
-      "The temperature controls how much randomness is in the output.",
+      "The temperature controls how much randomness is in the output.<br/>"+
+      "You can set a different temperature in your own prompt templates by adding a 'prompt-template' property to the block.",
   },
   {
     key: "openAIMaxTokens",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -190,6 +190,10 @@ const LogseqApp = () => {
     }
 
     const openAISettings = getOpenaiSettings();
+    // Set temperature of command instead of global temperature
+    if (command.temperature!=null && !Number.isNaN(command.temperature)) {
+      openAISettings.temperature = command.temperature;
+    }
     const response = await openAI(command.prompt + inputText, openAISettings);
     if (response) {
       return response;

--- a/src/ui/LogseqAI.tsx
+++ b/src/ui/LogseqAI.tsx
@@ -13,6 +13,7 @@ export interface Command {
   type: string;
   name: string;
   prompt: string;
+  temperature?: number;
   shortcut?: string;
 }
 


### PR DESCRIPTION
Hi.

The user can now set the 'prompt-temperature' property when defining the custom prompts.