### PR TITLE
fix(options): whisper use custom configuration

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -57,7 +57,7 @@ const retryOptions = {
 
 export async function whisper(file: File,openAiOptions:OpenAIOptions): Promise<string> {
     const apiKey = openAiOptions.apiKey;
-    const baseUrl = openAiOptions.completionEndpoint ? "https://api.openai.com/v1" : openAiOptions.completionEndpoint;
+    const baseUrl = openAiOptions.completionEndpoint ? openAiOptions.completionEndpoint : "https://api.openai.com/v1";
     const model = 'whisper-1';
   
     // Create a FormData object and append the file

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -24,7 +24,7 @@ export const settingsSchema: SettingSchemaDesc[] = [
   {
     key: "chatCompletionEndpoint",
     type: "string",
-    default: "http://api.openai.com/v1/",
+    default: "http://api.openai.com/v1",
     title: "OpenAI API Completion Endpoint",
     description: "The endpoint to use for OpenAI API completion requests. You shouldn't need to change this."
   },


### PR DESCRIPTION
At the moment, the baseurl configuration for Whisper isn't functioning properly. 
Additionally, there's an unnecessary '/' in the default base URL. Often, it gets appended with another "/", resulting in paths like http://api.openai.com/v1//chat/completions