### PR TITLE
Add support for oobabooga text generation webui API

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -29,6 +29,20 @@ export const settingsSchema: SettingSchemaDesc[] = [
     description: "The endpoint to use for OpenAI API completion requests. You shouldn't need to change this."
   },
   {
+    key: "useChatCompletionRequestMessage",
+    type: "boolean",
+    default: false,
+    title: "Use OpenAI Chat Completion Request Message",
+    description: "Send chat completion message using ChatCompletionRequestMessage interface rather than raw string. Useful for Oobabooga Text-Generation-WebUI. See https://github.com/oobabooga/text-generation-webui for more info.",
+  },
+  {
+    key: "chatCompletionCharacter",
+    type: "string",
+    default: "Assistant",
+    title: "Completion Character",
+    description: "Only used for Oobabooga Text-Generation-WebUI. See https://github.com/oobabooga/text-generation-webui for more info."
+  },
+  {
     key: "chatPrompt",
     type: "string",
     default: "Do not refer to yourself in your answers. Do not say as an AI language model...",
@@ -91,6 +105,8 @@ function unescapeNewlines(s: string) {
 export function getOpenaiSettings(): PluginOptions {
   const apiKey = logseq.settings!["openAIKey"];
   const completionEngine = logseq.settings!["openAICompletionEngine"];
+  const completionCharacter = logseq.settings!["chatCompletionCharacter"];
+  const useChatCompletionRequestMessage = logseq.settings!["useChatCompletionRequestMessage"];
   const injectPrefix = unescapeNewlines(logseq.settings!["injectPrefix"]);
   const temperature = Number.parseFloat(logseq.settings!["openAITemperature"]);
   const maxTokens = Number.parseInt(logseq.settings!["openAIMaxTokens"]);
@@ -102,6 +118,8 @@ export function getOpenaiSettings(): PluginOptions {
   return {
     apiKey,
     completionEngine,
+    completionCharacter,
+    useChatCompletionRequestMessage,
     temperature,
     maxTokens,
     dalleImageSize,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -163,7 +163,7 @@ const LogseqApp = () => {
     logseq.Editor.registerBlockContextMenuItem("gpt-page", runGptPage);
     logseq.Editor.registerSlashCommand("gpt-block", runGptBlock);
     logseq.Editor.registerBlockContextMenuItem("gpt-block", runGptBlock);
-    logseq.Editor.registerSlashCommand("dalle", runDalleBlock);
+logseq.Editor.registerSlashCommand("dalle", runDalleBlock);
     logseq.Editor.registerBlockContextMenuItem("dalle", runDalleBlock);
     logseq.Editor.registerSlashCommand("whisper", runWhisper);
     logseq.Editor.registerBlockContextMenuItem("whisper", runWhisper);


### PR DESCRIPTION
The **text-geneartion-webui** by [oobabooga](https://github.com/oobabooga) allows you to run language models (like ChatGPT) locally on your machine (or on some external server). It already features a drop-in replacement for OpenAI API as specified [here](https://github.com/oobabooga/text-generation-webui)

The only changes required is to: 
- Allow requests to be sent with `ChatCompletionRequestMessage` interface
- Add the `character` field to the request [#4320](https://github.com/oobabooga/text-generation-webui/issues/4320)

Have tested this locally, all seems fine. This shouldn't affect the existing OpenAI ChatGPT functionality, but will allow people to host/run local language models on servers/their machines.