### PR TITLE
support using deepseek models

### DIFF
--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -144,7 +144,7 @@ export async function openAI(
     baseURL: options.completionEndpoint
   });
   try {
-    if (engine.startsWith("gpt-3.5") || engine.startsWith("gpt-4")) {
+    if (engine.startsWith("gpt-3.5") || engine.startsWith("gpt-4") || engine.startsWith("deepseek")) {
       const inputMessages:OpenAI.Chat.CreateChatCompletionRequestMessage[] =  [{ role: "user", content: input }];
       if (openAiOptions.chatPrompt && openAiOptions.chatPrompt.length > 0) {
         inputMessages.unshift({ role: "system", content: openAiOptions.chatPrompt });
@@ -220,7 +220,7 @@ export async function openAIWithStream(
   const engine = options.completionEngine!;
 
   try {
-    if (engine.startsWith("gpt-3.5") || engine.startsWith("gpt-4")) {
+    if (engine.startsWith("gpt-3.5") || engine.startsWith("gpt-4") || engine.startsWith("deepseek")) {
       const inputMessages: OpenAI.Chat.CreateChatCompletionRequestMessage[] = [{ role: "user", content: input }];
       if (openAiOptions.chatPrompt && openAiOptions.chatPrompt.length > 0) {
         inputMessages.unshift({ role: "system", content: openAiOptions.chatPrompt });


### PR DESCRIPTION
I'd like to use deepseek models (using the same OpenAI API protocol, much cheaper than gtp4 and much stronger than gpt3) together with this plugin.

My usage:` 
in the plugin settings, set
* openai api key to deepseek api key, which looks like: `sk-123456....`
* endpoint to `https://api.deepseek.com`
* Completion engine to `deepseek-chat`, or `deepseek-reasoner`
* (Optional) clear up `OpenAI Chat Prompt` in settings
Then it worked for me locally for features like summarizing text.

Before this change it couldn't work due to the HTTPS request send the prompt in body.prompt, rather than in the messages payload.

Btw, its API doc: https://api-docs.deepseek.com/
